### PR TITLE
fix typo sining -> signing in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Or install it yourself as:
 
 ## Usage
 
-### Singing
+### Signing
 
 ```ruby
 require 'schnorr'


### PR DESCRIPTION
great library. I found this small typo while I was reading it as our reference.